### PR TITLE
Flush logging to ensure precise timings

### DIFF
--- a/wirelogd/main.py
+++ b/wirelogd/main.py
@@ -203,6 +203,7 @@ def run_loop(config: dict, log: logging.Logger):
                     peer['allowed-ips'],
                     peer['interface'],
                 )
+        log.handlers[0].flush()
         time.sleep(config['refresh'])
 
 


### PR DESCRIPTION
Sometime, systemd / python is buffering output, leading to delay display of information in log.

This flush stdout after each iteration, to ensure log are recorded more precisely.