### PR TITLE
Dont run setfacl if package is missing

### DIFF
--- a/DEBIAN/postinst
+++ b/DEBIAN/postinst
@@ -7,7 +7,9 @@ case "$1" in
         if [ -z "$2" ]; then
             if ! getent passwd wirelogd >>/dev/null 2>&1 ; then
                 useradd --home-dir /var/run/wirelogd --shell /usr/sbin/nologin --system --user-group wirelogd
-                setfacl -m u:wirelogd:rX,g:wirelogd:rX /etc/wireguard
+                if command -v setfacl >>/dev/null 2>&1 ; then
+                    setfacl -m u:wirelogd:rX,g:wirelogd:rX /etc/wireguard
+                fi
             fi
             systemctl enable --now wirelogd.service
         fi


### PR DESCRIPTION
Since it's not explicitly required, setfacl command may not exist on the target system, creating error during installation.

This ignore the error in such cases.